### PR TITLE
Loosen joi back to a caret range (^17.13.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "networks.json"
   ],
   "dependencies": {
-    "joi": "17.13.3",
+    "joi": "^17.13.3",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,7 +981,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.1"
     eslint-plugin-prettier: "npm:^5.1.3"
     jest: "npm:^29.7.0"
-    joi: "npm:17.13.3"
+    joi: "npm:^17.13.3"
     joi-to-json: "npm:^4.2.1"
     js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
@@ -3740,16 +3740,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joi@npm:17.13.3":
-  version: 17.13.3
-  resolution: "joi@npm:17.13.3"
+"joi@npm:^17.13.3":
+  version: 17.13.4
+  resolution: "joi@npm:17.13.4"
   dependencies:
     "@hapi/hoek": "npm:^9.3.0"
     "@hapi/topo": "npm:^5.1.0"
     "@sideway/address": "npm:^4.1.5"
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
-  checksum: 10c0/9262aef1da3f1bec5b03caf50c46368899fe03b8ff26cbe3d53af4584dd1049079fc97230bbf1500b6149db7cc765b9ee45f0deb24bb6fc3fa06229d7148c17f
+  checksum: 10c0/5addfef638e90eb6a45a72e3884128d8d9a80c487cb8bfcb949be179b875ad1095af347fa1bd05c4ebec2b2ccbc3f3db5f34501c8672ecd16100de2b77087122
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

`@subsquid/manifest` exact-pins `joi` to `17.13.3`. `@subsquid/cli` depends on `joi: ^17.13.3`, which floats to `17.13.4` (current latest 17.x). npm cannot satisfy an exact `17.13.3` and a floating `^17.13.3` with a single copy, so it installs both — `17.13.4` hoisted and `17.13.3` nested under manifest.

At runtime the CLI composes manifest's exported joi schemas (`JoiSquidName`/`JoiSquidSlot`/`JoiSquidTag`) into its own `Joi.object(...)`. joi stamps its version into every schema and `isSchema` asserts an exact `version` string match, so the two patch levels collide:

```
Error: Cannot mix different versions of joi schemas
  module: @oclif/core@3.27.0
  task: findCommand
  plugin: @subsquid/cli
```

This fires during oclif command discovery and breaks every `sqd` invocation in a global install. It is invisible to `tsc` (both copies expose identical types); the mismatch is purely the runtime version string.

## Root cause

The exact pin was introduced in `4a7fc8a` ("chore: bump joi version"), which changed `^17.12.0` -> `17.13.3`. It appears to have been an accidental caret-drop rather than a deliberate freeze: the Yarn-classic lockfile descriptor in that same commit was `joi@^17.13.3` (caret), inconsistent with the un-careted package.json — i.e. the lock was generated from an intended `^17.13.3` while the caret didn't make it into package.json. The commit intent was to *bump*, every other dependency kept its caret, and there is no recorded reason (no regression note) to freeze.

## Fix

Restore the caret: `"joi": "^17.13.3"`, and regenerate the lockfile so the descriptor matches. manifest now dedupes with `@subsquid/cli` to a single joi (`17.13.4`) while still coexisting with other reasonably-ranged joi consumers.

## Verification

- Dedupes to a single joi copy; `sqd --version` runs clean (0 "Cannot mix" warnings).
- Coexists: in a project also pinning `joi@17.9.0`, the foreign consumer keeps its own copy while cli+manifest share one.
- All 140 manifest tests pass on `17.13.4`.
